### PR TITLE
fix: initial automated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+# Releases are fully automated using [semantic-release](https://github.com/semantic-release/semantic-release/).
+#
+# The following commit message conventions determine which version is released:
+#
+# 1. `fix: ...` or `fix(scope name): ...` prefix in subject: bumps fix version, e.g. `1.2.3` → `1.2.4`
+# 2. `feat: ...` or `feat(scope name): ...` prefix in subject: bumps feature version, e.g. `1.2.3` → `1.3.0`
+# 3. `BREAKING CHANGE:` in body: bumps breaking version, e.g. `1.2.3` → `2.0.0`
+#
+# Only one version number is bumped at a time, the highest version change trumps the others.
+# Besides, publishing a new version to npm, semantic-release also creates a git tag and release
+# on GitHub, generates changelogs from the commit messages and puts them into the release notes.
+#
+# If the pull request looks good but does not follow the commit conventions, update the pull request title and use the <kbd>Squash & merge</kbd> button, at which point you can set a custom commit message.
+#
+# With each new release, a breaking version tag (e.g. `v1`, `v2`, etc) is created or updated.
+#
+# ## Rollback Latest Release
+#
+# Let's say `v1.2.3` include a bug and we want to roll back to `v1.2.2`. To accomplish that, the `v1` tag needs to be updated. That can be done using the following code
+#
+# ```
+# # update `v1` tag to point to `v1.2.2`
+# git tag --force v1 v1.2.2
+# git push --force --tags
+# ```
+
+name: 🚀 Release
+"on":
+  push:
+    branches:
+      - main
+      - beta
+      - "*.x"
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "lts/*"
+      - name: install semantic-release plugins
+        run: npm install --no-save semantic-release-plugin-github-breaking-version-tag
+      - name: write configuration
+        run: |
+          cat >.releaserc <<EOL
+          {
+            "branches": [
+              "+([0-9]).x",
+              "main",
+              {
+                "name": "beta",
+                "prerelease": true
+              }
+            ],
+            "plugins": [
+              "@semantic-release/commit-analyzer",
+              "@semantic-release/release-notes-generator",
+              "semantic-release-plugin-github-breaking-version-tag",
+              "@semantic-release/github"
+            ]
+          }
+          EOL
+      - name: Release the new version
+        run: npx semantic-release --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@
 # git tag --force v1 v1.2.2
 # git push --force --tags
 # ```
+#
+# Any questions? Ping @gr2m
 
 name: 🚀 Release
 "on":


### PR DESCRIPTION
@heiskr I created a test repository for demonstration and testing purposes ([accept invitation](https://github.com/gr2m/testing-semantic-release/invitations)). Feel free to edit the README.md file and use the commit conventions documented at the top of the release.yml workflow file to create new versions

I would recommend to enforce squashing commits using repository settings (only enable the "Allow squash merging" option in the "Pull Requests" section)

Let me know if you have any questions
